### PR TITLE
move ./nginx subdir into compile script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@ set -eo pipefail
 
 main() {
     APP_DIR=/app
-    BUILD_DIR=$1    # /tmp/build_76471de2-7dff-46b7-b331-c8dd07653def
+    BUILD_DIR=$1/nginx    # /tmp/build_76471de2-7dff-46b7-b331-c8dd07653def
     CACHE_DIR=$2    # /app/tmp/cache
     ENV_DIR=$3
     BUILDPACK_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )/.."


### PR DESCRIPTION
@nmccready @jessecstewart @realtyjustin 

This plus the map PR should fix the heroku deploy issue
